### PR TITLE
added /init.d containing quakejs for start/stop daemon

### DIFF
--- a/init.d/quakejs
+++ b/init.d/quakejs
@@ -1,0 +1,59 @@
+#!/bin/sh
+#
+# /etc/init.d/quakejs
+# Subsystem file for "quakejs" server
+#
+# chkconfig: 2345 95 05
+# description: QuakeJS server daemon
+#
+# processname: quakejs
+# pidfile: /var/run/quakejs.pid
+
+RETVAL=0
+prog="quakejs"
+
+start() {
+	echo "Starting $prog:"
+	daemonize -v -p /var/run/$prog.pid -c /home/quake/quakejs -u quake /usr/bin/node build/ioq3ded.js +set fs_game baseq3 set dedicated 1 +exec server.cfg
+	RETVAL=$?
+	[ "$RETVAL" = 0 ] && touch /var/lock/subsys/$prog
+	echo
+}
+
+stop() {
+	echo "Stopping $prog:"
+	killproc $prog -TERM
+	RETVAL=$?
+	[ "$RETVAL" = 0 ] && rm -f /var/lock/subsys/$prog
+	echo
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	restart)
+		stop
+		sleep 3
+		start
+		;;
+	condrestart)
+		if [ -f /var/lock/subsys/$prog ] ; then
+			stop
+			# avoid race
+			sleep 3
+			start
+		fi
+		;;
+	status)
+		status $prog
+		RETVAL=$?
+		;;
+	*)
+		echo $"Usage: $0 {start|stop|restart|condrestart|status}"
+		RETVAL=1
+esac
+exit $RETVAL

--- a/init.d/quakejs
+++ b/init.d/quakejs
@@ -1,5 +1,14 @@
 #!/bin/sh
 #
+### BEGIN INIT INFO
+# Provides:		quakejs
+# Required-Start:	$network
+# Required-Stop:
+# Default-Start:	2 3 4 5
+# Default-Stop:
+# Short-Description:	QuakeJS Server Daemon
+### END INIT INFO
+#
 # /etc/init.d/quakejs
 # Subsystem file for "quakejs" server
 #
@@ -8,11 +17,6 @@
 #
 # processname: quakejs
 # pidfile: /var/run/quakejs.pid
-#
-# script assumes QuakeJS is installed/cloned
-# to '/home/quake/quakejs' and that the user
-# 'quake' will run the game server. Change
-# line 19 to adjust this
 
 RETVAL=0
 prog="quakejs"

--- a/init.d/quakejs
+++ b/init.d/quakejs
@@ -8,6 +8,11 @@
 #
 # processname: quakejs
 # pidfile: /var/run/quakejs.pid
+#
+# script assumes QuakeJS is installed/cloned
+# to '/home/quake/quakejs' and that the user
+# 'quake' will run the game server. Change
+# line 19 to adjust this
 
 RETVAL=0
 prog="quakejs"


### PR DESCRIPTION
This pull request adds an `init.d` directory which contains `quakejs`.

`quakejs` is a start stop daemon script designed to be placed in `/etc/init.d/` on a Debian based system to allow the QuakeJS server to be daemonized.  This supports simple start/stop operation of the server as well as start-on-boot functionality.

Note that the script assumes the location of the server code is at `/home/quake/quakejs`.

See details about how this is setup and used at https://steamforge.net/wiki/index.php/How_to_setup_a_local_QuakeJS_server_under_Debian_9

This pull request is in conjunction with #54 & #56.