### PR TITLE
updated README.md with local game server/content server/play page ins…

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Configure a dedicated local server as described above in **Running a dedicated s
 
 Copy the files from `html` to your web server's root folder.  Run `html/get_assets.sh` to download files from http://content.quakejs.com.  Rename *quakejs* on line 77 of `html/index.html` to your server's hostname.
 
-Copy `init.d/quakejs` to `/etc/init.d/`, make it executable, and enable it by running `sudo update-rc.d quakejs defaults` (under Debian).
+Copy `init.d/quakejs` to `/etc/init.d/`, make it executable, and enable it by running `sudo update-rc.d quakejs defaults` and `sudo systemctl enable quakejs` (under Debian).
 
 *Step by step instructions can be found at https://steamforge.net/wiki/index.php/How_to_setup_a_local_QuakeJS_server_under_Debian_9*
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ seta sv_hostname "CHANGE ME"
 seta sv_maxclients 12
 seta g_motd "CHANGE ME"
 seta g_quadfactor 3
-seta g_gametype 0
+seta g_gametype 0y yyy y
 seta timelimit 15
 seta fraglimit 25
 seta g_weaponrespawn 3
@@ -129,6 +129,20 @@ Note: `./assets` is assumed to be the default asset directory. If you'd like to 
 
 Once the content server is available, you can use it by launching your local or dedicated server with `+set fs_cdn <server_address>`.
 
+## Running a local dedicated server, content server, and play page
+
+It is possible to run a QuakeJS server, Content Server, and Play Page entirely locally (for use on a LAN with no external internet connection required).
+
+Configure a dedicated local server as described above in **Running a dedicated server** and **baseq3 server, step-by-step**.
+
+Copy the files from `html` to your web server's root folder.  Run `html/get_assets.sh` to download files from http://content.quakejs.com.  Rename *quakejs* on line 77 of `html/index.html` to your server's hostname.
+
+Copy `init.d/quakejs` to `/etc/init.d/`, make it executable, and enable it by running `sudo update-rc.d quakejs defaults` (under Debian).
+
+*Step by step instructions can be found at https://steamforge.net/wiki/index.php/How_to_setup_a_local_QuakeJS_server_under_Debian_9*
+
 ## License
 
 MIT
+
+

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Configure a dedicated local server as described above in **Running a dedicated s
 
 Copy the files from `html` to your web server's root folder.  Run `html/get_assets.sh` to download files from http://content.quakejs.com.  Rename *quakejs* on line 77 of `html/index.html` to your server's hostname.
 
-Copy `init.d/quakejs` to `/etc/init.d/`, make it executable, and enable it by running `sudo update-rc.d quakejs defaults` and `sudo systemctl enable quakejs` (under Debian).
+Copy `init.d/quakejs` to `/etc/init.d/`, make it executable, and enable it by running `sudo update-rc.d quakejs defaults` (under Debian).
 
 *Step by step instructions can be found at https://steamforge.net/wiki/index.php/How_to_setup_a_local_QuakeJS_server_under_Debian_9*
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ seta sv_hostname "CHANGE ME"
 seta sv_maxclients 12
 seta g_motd "CHANGE ME"
 seta g_quadfactor 3
-seta g_gametype 0y yyy y
+seta g_gametype 0
 seta timelimit 15
 seta fraglimit 25
 seta g_weaponrespawn 3
@@ -144,5 +144,3 @@ Copy `init.d/quakejs` to `/etc/init.d/`, make it executable, and enable it by ru
 ## License
 
 MIT
-
-


### PR DESCRIPTION
…tructions

This pull request updated `README.md` to include a section at the bottom on setting up a completely local instance of QuakeJS complete with game server, content server, and play page.

See details about how this is setup and used at https://steamforge.net/wiki/index.php/How_to_setup_a_local_QuakeJS_server_under_Debian_9

This pull request is in conjunction with #54 & #55.